### PR TITLE
Switch to using objStat for file size, modified date, and created date.

### DIFF
--- a/src/clj_jargon/item_info.clj
+++ b/src/clj_jargon/item_info.clj
@@ -114,21 +114,15 @@
 
 (defn lastmod-date
   "Returns the date that the file/directory was last modified."
-  [cm ^String path]
+  [{^IRODSFileSystemAO cm-ao :fileSystemAO} ^String path]
   (validate-path-lengths path)
-  (cond
-    (is-dir? cm path)  (str (long (.getTime (.getModifiedAt (collection cm path)))))
-    (is-file? cm path) (str (long (.getTime (.getUpdatedAt (data-object cm path)))))
-    :else              nil))
+  (str (long (.getTime (.getModifiedAt (.getObjStat cm-ao path))))))
 
 (defn created-date
   "Returns the date that the file/directory was created."
-  [cm ^String path]
+  [{^IRODSFileSystemAO cm-ao :fileSystemAO} ^String path]
   (validate-path-lengths path)
-  (cond
-    (is-dir? cm path)  (str (long (.. (collection cm path) getCreatedAt getTime)))
-    (is-file? cm path) (str (long (.. (data-object cm path) getCreatedAt getTime)))
-    :else              nil))
+  (str (long (.getTime (.getCreatedAt (.getObjStat cm-ao path))))))
 
 (defn- dir-stat
   "Returns status information for a directory."
@@ -165,9 +159,9 @@
 
 (defn file-size
   "Returns the size of the file in bytes."
-  [cm ^String path]
+  [{^IRODSFileSystemAO cm-ao :fileSystemAO} ^String path]
   (validate-path-lengths path)
-  (.getDataSize (data-object cm path)))
+  (.getObjSize (.getObjStat cm-ao path)))
 
 (defn quota-map
   [^Quota quota-entry]


### PR DESCRIPTION
This is a lot faster than the more complex fetching done to create a full DataObject or Collection -- that full fetching fills out more fields (see https://github.com/DICE-UNC/jargon/blob/199e6015f3980aac5d1d062040ea9d2fa664ff20/jargon-core/src/main/java/org/irods/jargon/core/pub/DataAOHelper.java#L154) , but in these functions, we obviously don't need it; the more limited set of fields which the basic object stat returns are sufficient. Bonus, we don't have to care if something's a file or folder when we use this!

My testing here was with kifshare's anon-files handling; for a small file, this took the response time from 400 to 200ms with a primed cache (roughly 700-500 for the first requests).