### PR TITLE
CORE-9188 Allow create-ticket to create `write` tickets.

### DIFF
--- a/src/clj_jargon/tickets.clj
+++ b/src/clj_jargon/tickets.clj
@@ -43,10 +43,10 @@
     (.setTicketUsesLimit tas ticket-id uses-limit)))
 
 (defn create-ticket
-  [cm user fpath ticket-id & {:as ticket-opts}]
+  [cm user fpath ticket-id & {:keys [rw-mode] :as ticket-opts}]
   (validate-path-lengths fpath)
   (let [tas        (ticket-admin-service cm user)
-        read-mode  TicketCreateModeEnum/READ
+        read-mode  (if (= rw-mode :write) TicketCreateModeEnum/WRITE TicketCreateModeEnum/READ)
         new-ticket (.createTicket tas read-mode (file cm fpath) ticket-id)]
     (set-ticket-options ticket-id tas ticket-opts)
     new-ticket))


### PR DESCRIPTION
This PR will allow `clj-jargon.tickets/create-ticket` to create `write` tickets with a new `rw-mode` argument option.