### PR TITLE
Make permission changes use admin mode only when the connection is unproxied

### DIFF
--- a/src/clj_jargon/permissions.clj
+++ b/src/clj_jargon/permissions.clj
@@ -271,7 +271,7 @@
     own?   (.setAccessPermissionOwn dataobj zone fpath user)
     write? (.setAccessPermissionWrite dataobj zone fpath user)
     read?  (.setAccessPermissionRead dataobj zone fpath user)
-    true   (.removeAccessPermissionsForUser dataobj zone fpath user)))
+    :else  (.removeAccessPermissionsForUser dataobj zone fpath user)))
 
 (defn set-dataobj-perms
   [{^DataObjectAO dataobj :dataObjectAO zone :zone :as cm} user fpath read? write? own?]
@@ -297,7 +297,7 @@
     own?   (.setAccessPermissionOwn coll zone fpath user recursive?)
     write? (.setAccessPermissionWrite coll zone fpath user recursive?)
     read?  (.setAccessPermissionRead coll zone fpath user recursive?)
-    true   (.removeAccessPermissionForUser coll zone fpath user recursive?)))
+    :else  (.removeAccessPermissionForUser coll zone fpath user recursive?)))
 
 (defn set-coll-perms
   [{^CollectionAO coll :collectionAO zone :zone :as cm} user fpath read? write? own? recursive?]

--- a/src/clj_jargon/permissions.clj
+++ b/src/clj_jargon/permissions.clj
@@ -257,11 +257,11 @@
   [{^DataObjectAO dataobj :dataObjectAO zone :zone} user fpath read? write? own?]
   (validate-path-lengths fpath)
 
-  (.removeAccessPermissionsForUserInAdminMode dataobj zone fpath user)
   (cond
     own?   (.setAccessPermissionOwnInAdminMode dataobj zone fpath user)
     write? (.setAccessPermissionWriteInAdminMode dataobj zone fpath user)
-    read?  (.setAccessPermissionReadInAdminMode dataobj zone fpath user)))
+    read?  (.setAccessPermissionReadInAdminMode dataobj zone fpath user)
+    :else  (.removeAccessPermissionsForUserInAdminMode dataobj zone fpath user)))
 
 (defn- set-dataobj-perms-proxied
   [{^DataObjectAO dataobj :dataObjectAO zone :zone} user fpath read? write? own?]
@@ -282,12 +282,12 @@
 (defn- set-coll-perms-admin
   [{^CollectionAO coll :collectionAO zone :zone} user fpath read? write? own? recursive?]
   (validate-path-lengths fpath)
-  (.removeAccessPermissionForUserAsAdmin coll zone fpath user recursive?)
 
   (cond
     own?   (.setAccessPermissionOwnAsAdmin coll zone fpath user recursive?)
     write? (.setAccessPermissionWriteAsAdmin coll zone fpath user recursive?)
-    read?  (.setAccessPermissionReadAsAdmin coll zone fpath user recursive?)))
+    read?  (.setAccessPermissionReadAsAdmin coll zone fpath user recursive?)
+    :else  (.removeAccessPermissionForUserAsAdmin coll zone fpath user recursive?)))
 
 (defn- set-coll-perms-proxied
   [{^CollectionAO coll :collectionAO zone :zone} user fpath read? write? own? recursive?]

--- a/src/clj_jargon/permissions.clj
+++ b/src/clj_jargon/permissions.clj
@@ -324,6 +324,16 @@
            read?   (or write? (= :read permission))]
       (set-permissions cm user fpath read? write? own? recursive?))))
 
+(defn remove-permissions
+  "Remove permissions, recursively where applicable"
+  [cm user fpath]
+  (set-permissions cm user fpath false false false true))
+
+(defn remove-access-permissions
+  "Remove permissions, non-recursively where applicable"
+  [cm user abs-path]
+  (set-permissions cm user abs-path false false false false))
+
 (defn one-user-to-rule-them-all?
   [{^CollectionAndDataObjectListAndSearchAO lister :lister :as cm} user]
   (let [subdirs     (.listCollectionsUnderPathWithPermissions lister (ft/rm-last-slash (:home cm)) 0)
@@ -586,28 +596,6 @@
     max-perm
     fmt-perm))
 
-(defn remove-permissions
-  [{^DataObjectAO data-ao :dataObjectAO
-    ^CollectionAO collection-ao :collectionAO
-    zone :zone
-    :as cm} user fpath]
-  (validate-path-lengths fpath)
-  (case (item/object-type cm fpath)
-   :file
-    (.removeAccessPermissionsForUserInAdminMode
-     data-ao
-     zone
-     fpath
-     user)
-
-   :dir 
-    (.removeAccessPermissionForUserAsAdmin
-     collection-ao
-     zone
-     fpath
-     user
-     true)))
-
 (defn owns?
   [cm user fpath]
   (validate-path-lengths fpath)
@@ -615,28 +603,6 @@
     :file (owns-dataobject? cm user fpath)
     :dir  (owns-collection? cm user fpath)
     false))
-
-(defn remove-access-permissions
-  [{^DataObjectAO data-ao :dataObjectAO
-    ^CollectionAO collection-ao :collectionAO
-    zone :zone
-    :as cm} user abs-path]
-  (validate-path-lengths abs-path)
-  (case (item/object-type cm abs-path)
-   :file
-    (.removeAccessPermissionsForUserInAdminMode
-     data-ao
-     zone
-     abs-path
-     user)
-
-   :dir
-    (.removeAccessPermissionForUserAsAdmin
-     collection-ao
-     zone
-     abs-path
-     user
-     false)))
 
 (defn removed-owners
   [curr-user-perms set-of-new-owners]

--- a/src/clj_jargon/users.clj
+++ b/src/clj_jargon/users.clj
@@ -1,7 +1,8 @@
 (ns clj-jargon.users
   (:use [clj-jargon.validations]
         [clj-jargon.gen-query])
-  (:import [org.irods.jargon.core.exception DataNotFoundException]
+  (:import [org.irods.jargon.core.connection IRODSAccount]
+           [org.irods.jargon.core.exception DataNotFoundException]
            [org.irods.jargon.core.query RodsGenQueryEnum]
            [org.irods.jargon.core.pub UserGroupAO
                                       UserAO]
@@ -39,3 +40,8 @@
       (.findByName user-ao user)
       true)
     (catch DataNotFoundException d false)))
+
+(defn proxied?
+  "Returns true if this context map is using a proxied (client) user"
+  [{:keys [^IRODSAccount irodsAccount]}]
+  (.proxied irodsAccount))

--- a/src/clj_jargon/users.clj
+++ b/src/clj_jargon/users.clj
@@ -44,4 +44,6 @@
 (defn proxied?
   "Returns true if this context map is using a proxied (client) user"
   [{:keys [^IRODSAccount irodsAccount]}]
-  (.proxied irodsAccount))
+  (cond (not (= (.getUserName irodsAccount) (.getProxyName irodsAccount))) true
+        (not (= (.getZone irodsAccount) (.getProxyZone irodsAccount))) true
+        :else false))


### PR DESCRIPTION
CORE-789 is related here. Those things were failing because the proxied connection used for moves was trying to set/remove permissions using admin mode, and while the user would be allowed to set those permissions, they weren't allowed to use admin mode.

There may be more here, but this part is pretty self-contained so I thought I'd get it up for review.