### PR TITLE
CORE-1893 Update clj-jargon.item-info/trash-base-dir

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.cyverse/clj-jargon "3.0.6-SNAPSHOT"
+(defproject org.cyverse/clj-jargon "3.1.0-SNAPSHOT"
   :description "Clojure API on top of iRODS's jargon-core."
   :url "https://github.com/cyverse-de/clj-jargon"
   :license {:name "BSD"

--- a/src/clj_jargon/item_info.clj
+++ b/src/clj_jargon/item_info.clj
@@ -21,16 +21,18 @@
 
 
 (defn ^String trash-base-dir
-  "Returns the base trash folder for a specified user.
+  "Returns the base trash folder for all users or for a specified user.
 
    Parameters:
-     zone - he name of the authenication zone
-     user - the username of the user's trash folder to look up.
+     zone - the name of the authentication zone
+     user - (optional) the username of the user's trash folder to look up.
 
    Returns:
      It returns the absolute path to the trash folder."
-  [^String zone ^String user]
-  (ft/path-join "/" zone "trash" "home" user))
+  ([^String zone]
+   (ft/path-join "/" zone "trash" "home"))
+  ([^String zone ^String user]
+   (ft/path-join (trash-base-dir zone) user)))
 
 
 (defn ^IRODSFile file

--- a/src/clj_jargon/permissions.clj
+++ b/src/clj_jargon/permissions.clj
@@ -546,7 +546,7 @@
   (let [user-hm   (ft/rm-last-slash (ft/path-join "/" (:zone cm) "home" user))
         parent    (ft/dirname path)
         base-dirs #{(ft/rm-last-slash (:home cm))
-                    (item/trash-base-dir (:zone cm) (:user cm))
+                    (item/trash-base-dir (:zone cm))
                     user-hm}]
     (process-perms
      (fn [{sharee :user}]
@@ -559,8 +559,7 @@
 (defn make-file-accessible
   "Ensures that a file is accessible to all users that have access to the file."
   [cm path user admin-users]
-  (let [parent    (ft/dirname path)
-        base-dirs #{(ft/rm-last-slash (:home cm)) (item/trash-base-dir (:zone cm) (:user cm))}]
+  (let [base-dirs #{(ft/rm-last-slash (:home cm)) (item/trash-base-dir (:zone cm))}]
     (process-perms
      (fn [{sharee :user}]
        (process-parent-dirs (partial set-readable cm sharee true) #(not (base-dirs %)) path))


### PR DESCRIPTION
This PR will remove the DE proxy user name from `clj-jargon.item-info/trash-base-dir` so that items are put into the same trash paths as used by `irm`.