### PR TITLE
Update dependencies and gate on dependency conflicts

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,30 @@
   :plugins [[jonase/eastwood "1.4.3"]
             [lein-ancient "1.0.0"]
             [test2junit "1.4.4"]]
+  ;; Records versions Leiningen already resolves, read off the resolved
+  ;; classpath rather than copied from lein's "Consider using these
+  ;; :managed-dependencies" hint -- that hint names the version that LOST the
+  ;; conflict, so pasting it would be a silent upgrade. Most of these arbitrate
+  ;; metosin/compojure-api 1.1.14, the final release of an archived project whose
+  ;; transitives disagree with each other, and clj-http vs buddy-core.
+  ;;
+  ;; The jackson-* entries hold the family at the 2.14.1 that jargon-core
+  ;; 4.3.7.0-RELEASE brings. jargon-core is pinned :upgrade false for iRODS
+  ;; compatibility, so jackson cannot move ahead of it without moving jargon too.
+  :managed-dependencies [[cheshire "5.13.0"]
+                         [com.fasterxml.jackson.core/jackson-annotations "2.14.1"]
+                         [com.fasterxml.jackson.core/jackson-core "2.14.1"]
+                         [com.fasterxml.jackson.core/jackson-databind "2.14.1"]
+                         [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.14.1"]
+                         [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.14.1"]
+                         [commons-codec "1.15"]
+                         [commons-io "2.11.0"]
+                         [prismatic/schema "1.1.12"]
+                         [ring/ring-codec "1.1.0"]
+                         [ring/ring-core "1.6.3"]]
+  ;; Fail the build on a new dependency conflict rather than printing a
+  ;; warning nobody reads.
+  :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.12.5"]
                  [org.clojure/tools.logging "1.3.1"]
                  [org.irods.jargon/jargon-core "4.3.7.0-RELEASE"

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
   :plugins [[jonase/eastwood "1.4.3"]
-            [lein-ancient "0.7.0"]
+            [lein-ancient "1.0.0"]
             [test2junit "1.4.4"]]
   :dependencies [[org.clojure/clojure "1.12.5"]
                  [org.clojure/tools.logging "1.3.1"]

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                   :exclusions [[com.fasterxml.jackson.core/jackson-databind]]]
                  [dev.weavejester/medley "1.10.0"]
                  [slingshot "0.12.2"]
-                 [org.cyverse/clojure-commons "3.0.12"]]
+                 [org.cyverse/clojure-commons "3.0.13"]]
   :profiles {:repl {:source-paths ["repl"]}}
   :eastwood {:exclude-linters [:unlimited-use :non-dynamic-earmuffs]}
   :repositories [["cyverse-de"


### PR DESCRIPTION
Part of a fleet-wide pass over the DE Clojure repos to clear Leiningen's
"Possibly confusing dependencies" reports and bring dependencies current.
**12 warnings → 0.**

## Changes

- `build: normalize plugin and Clojure versions` — lein-ancient 1.0.0
- `deps: update clojure-commons to 3.0.13`
- `build: fail the build on confusing dependencies` — `:pedantic? :abort` + `:managed-dependencies`

## No cider-nrepl exclusion needed

Earlier repos in this pass carry an interim `:exclusions [cider/cider-nrepl]`
workaround, because published `org.cyverse` poms declared that REPL tool at
compile scope. Not needed here: `clojure-commons` 3.0.13 dropped it. Verified —
0 cider entries on the resolved classpath.

## cheshire deliberately stays at 5.13.0

This is the one repo in the pass where I did **not** take the cheshire 6 upgrade,
and it is worth explaining.

`jargon-core` is pinned `:upgrade false` at `4.3.7.0-RELEASE` for iRODS
compatibility, and it brings jackson 2.14.1. On `main` all five jackson
artifacts resolve coherently at 2.14.1 — that is deliberate, and the explicit
`jackson-dataformat-cbor`/`-smile` pins at 2.14.1 exist to keep it that way.

I tried the upgrade first. cheshire 6.2.0 brings `jackson-core` 2.21.1, and the
result was `core`/`annotations`/`databind` at 2.14.1 against `cbor`/`smile` at
2.21.1 — a split family, which surfaces as a runtime `NoSuchMethodError` rather
than a resolution failure. Tests still passed, which is exactly why this is
worth flagging. Moving jackson here means moving jargon, so it belongs in its
own change alongside an iRODS compatibility check.

The `:managed-dependencies` block therefore holds jackson at 2.14.1 explicitly,
making that constraint visible instead of incidental.

## On the rest of `:managed-dependencies`

Everything else records a version Leiningen **already resolves**, read off the
resolved classpath rather than copied from lein's own
`Consider using these :managed-dependencies:` hint — that hint names the version
that *lost* the conflict, so pasting it would be a silent upgrade. The
`commons-io` entry is the clearest case: jargon-core wants 2.11.0 and
clj-http wants 2.16.1, and jargon-core currently wins.

## Verification

```
confusing-dep warnings   12 -> 0
lein deps :tree          exit 0 (default and +repl profiles)
lein check               exit 0 (compiles every namespace)
lein test                8 tests, 154 assertions, 0 failures
jackson family           coherent at 2.14.1, unchanged from main
```

## Unrelated, noticed while here

`:repositories` points at `https://raw.github.com/cyverse-de/mvn/...` and
`raw.github.com/DICE-UNC/DICE-Maven/...`. `raw.github.com` is a legacy hostname
(now `raw.githubusercontent.com`). Resolution currently works, so I left it
alone, but it is fragile and worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)